### PR TITLE
build: remove future package

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -3,4 +3,3 @@
 ansible==6.4.0                     # GPL v3
 boto==2.38.0                        # MIT -- used for ec2 inventory
 boto3==1.16.0                        # MIT -- used for emr deployment
-future==0.17.1                      # MIT

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,8 +20,6 @@ cffi==1.15.1
     # via cryptography
 cryptography==38.0.1
     # via ansible-core
-future==0.17.1
-    # via -r requirements/base.in
 jinja2==3.1.2
     # via ansible-core
 jmespath==0.10.0


### PR DESCRIPTION
## Description
- As uncovered in https://pyup.io/vulnerabilities/CVE-2022-40899/52510/, the `future` package is not secure to be used.
- `arbi-bom` is removing `future` package from all repos so this PR is being created under this effort.